### PR TITLE
Update auto tag and release process

### DIFF
--- a/.github/workflows/ci-cd-pipeline.yml
+++ b/.github/workflows/ci-cd-pipeline.yml
@@ -69,14 +69,14 @@ jobs:
           docker build -t myapp:${{ github.ref_name }}-production .
       - name: Generate new tag and release
         id: tag_version
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: ncipollo/release-action
         with:
           tag_name: ${{ github.ref_name }}
           release_name: Release ${{ github.ref_name }}
           draft: false
           prerelease: false
+          body: "Release of version ${{ github.ref_name }}"
+          token: ${{ secrets.GITHUB_TOKEN }}
 
   final-verification:
     name: Final Verification
@@ -85,3 +85,4 @@ jobs:
     steps:
       - name: Check completion
         run: echo "All stages completed successfully"
+


### PR DESCRIPTION
Related to #18

Updates the auto tag and release process in the CI/CD pipeline to use `ncipollo/release-action` instead of the deprecated `actions/create-release`.

- **Replaces** the `actions/create-release@v1` with `ncipollo/release-action` in the `production` job of the `.github/workflows/ci-cd-pipeline.yml` file. This change aligns with the latest practices and ensures continued support.
- **Adds** additional parameters required by `ncipollo/release-action`, including `body` and `token`, to the `with` block of the release step. This ensures the action has all necessary information to create a release.
- **Removes** the `env` block from the release step as it is no longer needed with the new action.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/igorcosta/api_workspace/issues/18?shareId=258a8eb0-d1cd-4ba1-95cf-1b70897c0d4c).