### PR TITLE
Fix CI/CD pipeline trigger configuration

### DIFF
--- a/.github/workflows/ci-cd-pipeline.yml
+++ b/.github/workflows/ci-cd-pipeline.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - dev
     tags:
-    - '**'
+      - '**'
   pull_request:
     branches:
       - main
@@ -86,4 +86,5 @@ jobs:
     steps:
       - name: Check completion
         run: echo "All stages completed successfully"
+
 


### PR DESCRIPTION
Related to #17

Corrects the trigger conditions in the `.github/workflows/ci-cd-pipeline.yml` file to ensure proper pipeline execution.

- Fixes the indentation for the `tags` key under the `push` trigger to align with the YAML syntax requirements, ensuring that the pipeline triggers on tag pushes that match the pattern `**`.
- Maintains the existing triggers for push to the `dev` branch and pull requests to the `main` branch, as specified in the issue.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/igorcosta/api_workspace/issues/17?shareId=2075d189-7601-43d2-8d14-629db6f4ac34).