### PR TITLE
Update lint configuration and permissions

### DIFF
--- a/.github/workflows/ci-cd-pipeline.yml
+++ b/.github/workflows/ci-cd-pipeline.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Lint Code Base
-        uses: super-linter/slim@v6
+        uses: super-linter/super-linter/slim@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DEFAULT_BRANCH: main

--- a/.github/workflows/ci-cd-pipeline.yml
+++ b/.github/workflows/ci-cd-pipeline.yml
@@ -15,15 +15,21 @@ jobs:
   super-lint:
     name: Super Lint
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      - name: Lint Code Base
-        uses: github/super-linter@v3
         with:
-          linter_rules_path: .github/linters
-          DEFAULT_BRANCH: main
+          fetch-depth: 0
+      - name: Lint Code Base
+        uses: super-linter/slim@v6
+        env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DEFAULT_BRANCH: main
+          FILTER_REGEX_EXCLUDE: docs/tool/.*
+          VALIDATE_MARKDOWN: true
+          VALIDATE_YAML: true
 
   development:
     name: Development Stage


### PR DESCRIPTION
Related to #24

Updates the CI/CD pipeline configuration to enhance linting capabilities and enforce security measures.

- **Enhances linting**: Replaces the lint step in the `.github/workflows/ci-cd-pipeline.yml` file from `github/super-linter@v3` to `super-linter/slim@v6`, incorporating configurations for improved code quality checks. This includes setting `FILTER_REGEX_EXCLUDE` to ignore specific directories, enabling `VALIDATE_MARKDOWN` and `VALIDATE_YAML` to ensure these file types are properly linted.
- **Improves security**: Adds `permissions` with `contents: read` to the lint job, restricting the job's permissions to only read the repository contents. This follows best practices for GitHub Actions security by minimizing permissions.
- **Optimizes checkout**: Adjusts the `actions/checkout@v4` step to use `fetch-depth: 0`, ensuring a complete history is fetched for comprehensive linting and analysis.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/igorcosta/api_workspace/issues/24?shareId=c2115cf1-13cb-4716-94f6-a1361c2db89a).