### PR TITLE
Enhance markdown linting in CI/CD pipeline

### DIFF
--- a/.github/workflows/ci-cd-pipeline.yml
+++ b/.github/workflows/ci-cd-pipeline.yml
@@ -30,6 +30,7 @@ jobs:
           FILTER_REGEX_EXCLUDE: docs/tool/.*
           VALIDATE_MARKDOWN: true
           VALIDATE_YAML: true
+          FAIL_ON_ERROR: true
 
   development:
     name: Development Stage


### PR DESCRIPTION
Updates the CI/CD pipeline configuration to enforce markdown linting failures.

- Adds the `FAIL_ON_ERROR: true` environment variable to the `Lint Code Base` step in the `.github/workflows/ci-cd-pipeline.yml` file. This ensures that the build process will fail if there are any markdown linting errors, aligning with the objective to enforce stricter linting rules for markdown files.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/igorcosta/api_workspace?shareId=2ec5602f-04bc-4fe3-8f5b-c51ab819917e).