### PR TITLE
Update lint configuration to ignore specific files

### DIFF
--- a/.github/workflows/ci-cd-pipeline.yml
+++ b/.github/workflows/ci-cd-pipeline.yml
@@ -27,7 +27,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DEFAULT_BRANCH: main
-          FILTER_REGEX_EXCLUDE: docs/tool/.*
+          FILTER_REGEX_EXCLUDE: .github/ISSUE_TEMPLATE/.*|README.md
           VALIDATE_MARKDOWN: true
           VALIDATE_YAML: true
           FAIL_ON_ERROR: true


### PR DESCRIPTION
Updates the linting configuration to ignore specific files and directories.

- Modifies the `FILTER_REGEX_EXCLUDE` environment variable in the `.github/workflows/ci-cd-pipeline.yml` file to ignore files in the `.github/ISSUE_TEMPLATE/` directory and the `README.md` file during linting.
- Removes the previous exclusion for the `docs/tool/.*` directory, ensuring that only the specified files and directories are ignored by the linting process.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/igorcosta/api_workspace?shareId=626da3bf-54ff-415b-97e1-d3b32eff2af0).