### PR TITLE
Update CI/CD pipeline for main branch and tag handling

### DIFF
--- a/.github/workflows/ci-cd-pipeline.yml
+++ b/.github/workflows/ci-cd-pipeline.yml
@@ -32,10 +32,25 @@ jobs:
           VALIDATE_YAML: true
           FAIL_ON_ERROR: true
 
+  tag-verification:
+    name: Tag Verification and Increment
+    needs: super-lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Verify and Increment Tag
+        id: verify_tag
+        uses: mathieudutour/github-tag-action@v5.6
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          default_bump: patch
+          release_branches: main
+
   development:
     name: Development Stage
-    needs: super-lint
-    if: github.ref == 'refs/heads/dev'
+    needs: tag-verification
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Updates the CI/CD pipeline configuration to trigger on the main branch and adds tag verification and incrementation.

- **Branch Trigger Update**: Changes the `development` job's trigger condition from `refs/heads/dev` to `refs/heads/main` to align with the task requirement of triggering jobs on pushes to the `main` branch.
- **Tag Verification and Incrementation**: Introduces a new job `tag-verification` that checks for the latest tag and increments it if necessary. This job uses `mathieudutour/github-tag-action@v5.6` and is set to run after `super-lint` and before the `development` job, ensuring that tags are verified and incremented as needed for compatibility with the last auto-release tag.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/igorcosta/api_workspace?shareId=fc9b7671-7b0c-46a6-b6e2-a494e19b2bab).