### PR TITLE
Add Docker deployment instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,28 @@ To set up the project locally, follow these steps:
 
 This will start the API server, making it accessible on `http://localhost:8000`. You can now use the API endpoints as defined in the project documentation.
 
+## Docker Deployment
+
+To deploy this API using Docker, follow these steps:
+
+1. Build the Docker image:
+   ```
+   docker build -t api_workspace .
+   ```
+   This command builds a Docker image named `api_workspace` using the `Dockerfile` in the current directory.
+
+2. Run the Docker container:
+   ```
+   docker run -p 80:80 api_workspace
+   ```
+   This command runs the `api_workspace` image as a container, mapping port 80 from the container to port 80 on the host machine.
+
+For production deployment, consider setting environment variables within the Docker container to configure the application appropriately.
+
+For advanced deployment options and troubleshooting, refer to the [Docker documentation](https://docs.docker.com/).
+
+For a comprehensive list of Docker commands, visit the [Docker commands documentation](https://docs.docker.com/engine/reference/commandline/cli/).
+
 ## Work Endpoints
 
 The API supports the following endpoints for managing work information:


### PR DESCRIPTION
Adds a new "Docker Deployment" section to the `README.md` file for the `igorcosta/api_workspace` repository, providing detailed instructions on deploying the API using Docker.

- **Introduces a "Docker Deployment" section** after the "Local Development" section, detailing the process to build and run the API using Docker.
  - Includes commands to build a Docker image and run a container, mapping port 80 from the container to the host.
  - Advises on setting environment variables for production deployment within the Docker container.
  - Recommends checking the Docker documentation for advanced deployment options and troubleshooting.
  - Provides a link to the Docker commands documentation for further reference.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/igorcosta/api_workspace?shareId=aaf4b4b9-e849-4f70-8970-b1b1ed1ad5dc).